### PR TITLE
Modified reset_odm to use threading in backend.

### DIFF
--- a/src/app_flask_backend.py
+++ b/src/app_flask_backend.py
@@ -807,15 +807,14 @@ def run_odm_endpoint():
                          temp_dir, 
                          reconstruction_quality, 
                          custom_options)
-    
     try:
         # Reset ODM if needed before proceeding 
-        reset_thread = threading.Thread(target=reset_odm, args=(args.data_root_dir))
+        reset_thread = threading.Thread(target=reset_odm, args=(args,), daemon=True)
         reset_thread.start()
         # Ensure reset thread is finished before trying to access temp folder 
         reset_thread.join()
         # Run ODM in a separate thread
-        thread = threading.Thread(target=run_odm, args=(args,))
+        thread = threading.Thread(target=run_odm, args=(args,), daemon=True)
         thread.start()
         
         # Run progress tracker

--- a/src/scripts/orthomosaic_generation.py
+++ b/src/scripts/orthomosaic_generation.py
@@ -194,9 +194,10 @@ def make_odm_args(data_root_dir, location, population, date, year, experiment, p
 
     return args
 
-def reset_odm(data_root_dir):
+def reset_odm(args):
     # May be more appropriate to rename as "prep_odm" in the future to clarify functionality
     # This function now contains checks for existing processed data previously in run_odm
+    drd = args.data_root_dir
     pth = args.temp_dir
     recipe_file = os.path.join(pth, 'code', 'recipe.yaml')
     reset_odm_temp = False
@@ -215,8 +216,9 @@ def reset_odm(data_root_dir):
                 reset_odm_temp = True
     else:
         reset_odm_temp = True
-    temp_path = os.path.join(data_root_dir, 'temp')
+    
     if reset_odm_temp:
+        temp_path = os.path.join(drd, 'temp')
         while os.path.exists(temp_path):
             shutil.rmtree(temp_path)
 


### PR DESCRIPTION
- Modified reset_odm to contain code previously in run_odm used to check if processed data already existed and checks for if reset was necessary.
- Ran reset_odm from backend with threading and thread.join() to ensure reset occurs before moving on to monitoring
- Found previous error with shutil.rmtree was occurring due to temp files being accessed by monitor_log_updates (deletion is prevented if files are in use)
- Resolves issue #30 in GEMINI-App